### PR TITLE
Fix to allow import/use module from any folder

### DIFF
--- a/secp256k1.py
+++ b/secp256k1.py
@@ -16,7 +16,8 @@ N = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141
 Zero=b'\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 #==============================================================================
 if platform.system().lower().startswith('win'):
-    dllfile = 'ice_secp256k1.dll'
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    dllfile = dir_path + '/ice_secp256k1.dll'
     if os.path.isfile(dllfile) == True:
         pathdll = os.path.realpath(dllfile)
         ice = ctypes.CDLL(pathdll)
@@ -24,7 +25,8 @@ if platform.system().lower().startswith('win'):
         print('File {} not found'.format(dllfile))
     
 elif platform.system().lower().startswith('lin'):
-    dllfile = 'ice_secp256k1.so'
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    dllfile = dir_path + '/ice_secp256k1.so'
     if os.path.isfile(dllfile) == True:
         pathdll = os.path.realpath(dllfile)
         ice = ctypes.CDLL(pathdll)


### PR DESCRIPTION
Load the shared library "ice_secp256k1.dll" or "ice_secp256k1.so" located in the same directory as the python module. By this fix the user can import the module from *ANY* directory using Python's CLI or IDE. Without this fix, the user can only import the module if the current working directory is the directory of this module.